### PR TITLE
remove duplicate module and api tag declarations

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -24,7 +24,6 @@ import { UserInterceptor } from '@modules/auth/interceptors/user.interceptor';
     PrismaModule,
     AuthModule,
     UserModule,
-    UserModule,
     ReviewsModule,
   ],
   controllers: [AppController],

--- a/src/modules/reviews/reviews.controller.ts
+++ b/src/modules/reviews/reviews.controller.ts
@@ -15,7 +15,6 @@ import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { BaseQueryDto } from '@shared/dtos/base-query.dto';
 
 @ApiTags('reviews')
-@ApiTags('reviews')
 @Controller('reviews')
 export class ReviewsController {
   constructor(private readonly reviewsService: ReviewsService) {}


### PR DESCRIPTION
## Problem

Two accidental duplicate declarations exist in the codebase:

- `src/app.module.ts` imports `UserModule` twice in the `imports` array.
- `src/modules/reviews/reviews.controller.ts` applies `@ApiTags('reviews')` to the controller twice.

Both are no-ops at runtime for Nest and Swagger but are misleading when reading the code, and show up as duplicates in the generated OpenAPI document.

## Approach

Removed the duplicate line in each file. No behavior change, no API change, no schema change.

## Testing

- `npm run lint:check` — clean
- `npm run typecheck` — clean
- `npm test` — 76 passed / 12 suites

## Scope

Narrowly scoped cleanup. No dependencies added, no config changes, no new files.