### PR TITLE
add .env.example for local setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,23 @@
+# Database
+DATABASE_URL="postgresql://USER:PASSWORD@HOST:PORT/DATABASE"
+
+# Auth
+JWT_SECRET="replace-with-a-long-random-secret"
+JWT_EXPIRES_IN="1d"
+
+# Encrypts first_name and last_name before storage. Falls back to JWT_SECRET when unset.
+USER_DATA_ENCRYPTION_KEY="replace-with-a-separate-long-random-secret"
+
+# Password reset OTP
+PASSWORD_RESET_OTP_TTL_MINUTES="10"
+PASSWORD_RESET_OTP_MAX_ATTEMPTS="5"
+
+# LinkedIn OAuth (required for /auth/linkedin)
+LINKEDIN_CLIENT_ID=""
+LINKEDIN_CLIENT_SECRET=""
+LINKEDIN_CALLBACK_URL="http://localhost:3000/auth/linkedin/callback"
+
+# Server
+PORT="3000"
+CORS_ORIGIN="*"
+NODE_ENV="development"


### PR DESCRIPTION
## Problem

New contributors setting up the project locally have to scan both the README and the source to discover all environment variables. The README lists five, but the code actually consumes twelve — including LinkedIn OAuth credentials that are passed to `configService.getOrThrow(...)` and will crash the app at startup when missing. There is no template file to copy into `.env`.

## Approach

Add a `.env.example` at the project root covering every environment variable the codebase references, with placeholders and defaults matching what the code expects.

Required (app fails to start without them):

- `DATABASE_URL`
- `JWT_SECRET`
- `LINKEDIN_CLIENT_ID`
- `LINKEDIN_CLIENT_SECRET`
- `LINKEDIN_CALLBACK_URL`

Optional with defaults (documented to make the complete surface discoverable):

- `JWT_EXPIRES_IN`, `USER_DATA_ENCRYPTION_KEY`, `PASSWORD_RESET_OTP_TTL_MINUTES`, `PASSWORD_RESET_OTP_MAX_ATTEMPTS`, `PORT`, `CORS_ORIGIN`, `NODE_ENV`

`.env` is already ignored by `.gitignore`; `.env.example` is not, so it is tracked as intended.

## Testing

- `npm run lint:check` — clean
- `npm run typecheck` — clean
- `npm test` — 76 passed / 12 suites

## Scope

Strictly additive — one new file, no source changes, no dependency changes. The README's environment section is intentionally untouched; updating it to reference the example file can be a follow-up if preferred.