### PR TITLE
remove invalid linkedin oauth scopes

### DIFF
--- a/src/modules/auth/strategies/linkedin.strategy.ts
+++ b/src/modules/auth/strategies/linkedin.strategy.ts
@@ -10,7 +10,7 @@ export class LinkedInStrategy extends PassportStrategy(Strategy, 'linkedin') {
       clientID: configService.getOrThrow<string>('LINKEDIN_CLIENT_ID'),
       clientSecret: configService.getOrThrow<string>('LINKEDIN_CLIENT_SECRET'),
       callbackURL: configService.getOrThrow<string>('LINKEDIN_CALLBACK_URL'),
-      scope: ['r_verify', 'openid', 'profile', 'email', 'r_profile_basicinfo'],
+      scope: ['openid', 'profile', 'email'],
     });
   }
 


### PR DESCRIPTION
## Problem

`LinkedInStrategy` requests five scopes: `r_verify`, `openid`, `profile`, `email`, `r_profile_basicinfo`. Two of those are invalid — LinkedIn's current OAuth / OIDC surface does not recognize `r_verify` or `r_profile_basicinfo`. Depending on the LinkedIn app configuration, requesting unrecognized scopes either:

- causes LinkedIn to reject the authorization request outright, or
- silently drops the unknown scopes and returns only what the app is actually approved for.

The service already accounts for the latter case: `auth.service.ts:88` hard-codes the scopes stored back on the `oauth_account` record as `['openid', 'profile', 'email']`, matching what LinkedIn grants. The strategy just asks for more than it should.

## Approach

Reduce `LinkedInStrategy`'s scope list to the three OIDC scopes that LinkedIn actually grants and the code already expects: `openid`, `profile`, `email`.

## Testing

- `npm run lint:check` — clean
- `npm run typecheck` — clean
- `npm test` — 76 passed / 12 suites

## Scope

Single-line change in `src/modules/auth/strategies/linkedin.strategy.ts`. No behavior change on the Nest side; the effect is a cleaner authorization request to LinkedIn that won't risk rejection for unknown scopes.