### PR TITLE
fix review endpoint id types and validate create review dto

### DIFF
--- a/src/modules/reviews/dto/create-review.dto.ts
+++ b/src/modules/reviews/dto/create-review.dto.ts
@@ -1,1 +1,63 @@
-export class CreateReviewDto {}
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
+import {
+  IsBoolean,
+  IsInt,
+  IsOptional,
+  IsString,
+  Max,
+  Min,
+  MinLength,
+} from 'class-validator';
+
+const trim = ({ value }: { value: unknown }) =>
+  typeof value === 'string' ? value.trim() : value;
+
+export class CreateReviewDto {
+  @ApiProperty({
+    example: 'cm9company123',
+    description: 'The company identifier for the review',
+  })
+  @IsString()
+  @MinLength(1)
+  @Transform(trim)
+  company_id!: string;
+
+  @ApiProperty({
+    example: 'Strong engineering culture with supportive managers.',
+    description: 'The review body',
+  })
+  @IsString()
+  @MinLength(1)
+  @Transform(trim)
+  body!: string;
+
+  @ApiProperty({
+    example: 4,
+    description: 'The overall rating for the company review',
+    minimum: 1,
+    maximum: 5,
+  })
+  @IsInt()
+  @Min(1)
+  @Max(5)
+  overall_rating!: number;
+
+  @ApiPropertyOptional({
+    example: 'Former full-time backend engineer',
+    description: 'Optional employment context for the review',
+  })
+  @IsOptional()
+  @IsString()
+  @MinLength(1)
+  @Transform(trim)
+  employment_context?: string;
+
+  @ApiPropertyOptional({
+    example: true,
+    description: 'Whether the reviewer would recommend the company',
+  })
+  @IsOptional()
+  @IsBoolean()
+  would_recommend?: boolean;
+}

--- a/src/modules/reviews/reviews.controller.ts
+++ b/src/modules/reviews/reviews.controller.ts
@@ -42,7 +42,7 @@ export class ReviewsController {
   @ApiResponse({ status: 200, description: 'Return a single review' })
   @ApiResponse({ status: 404, description: 'Review not found' })
   findOne(@Param('id') id: string): ApiSuccessResponse<string> {
-    return this.reviewsService.findOne(+id);
+    return this.reviewsService.findOne(id);
   }
 
   @Patch(':id')
@@ -52,8 +52,8 @@ export class ReviewsController {
   update(
     @Param('id') id: string,
     @Body() updateReviewDto: UpdateReviewDto,
-  ): ApiSuccessResponse<{ id: number; review: UpdateReviewDto }> {
-    return this.reviewsService.update(+id, updateReviewDto);
+  ): ApiSuccessResponse<{ id: string; review: UpdateReviewDto }> {
+    return this.reviewsService.update(id, updateReviewDto);
   }
 
   @Delete(':id')
@@ -61,6 +61,6 @@ export class ReviewsController {
   @ApiResponse({ status: 200, description: 'Review deleted successfully' })
   @ApiResponse({ status: 404, description: 'Review not found' })
   remove(@Param('id') id: string): ApiSuccessResponse<string> {
-    return this.reviewsService.remove(+id);
+    return this.reviewsService.remove(id);
   }
 }

--- a/src/modules/reviews/reviews.service.ts
+++ b/src/modules/reviews/reviews.service.ts
@@ -24,7 +24,7 @@ export class ReviewsService {
     return CrudResponse(DbModels.COMPANY_REVIEW, CrudEnums.READ, []);
   }
 
-  findOne(id: number): ApiSuccessResponse<string> {
+  findOne(id: string): ApiSuccessResponse<string> {
     return CrudResponse(
       DbModels.COMPANY_REVIEW,
       CrudEnums.READ,
@@ -33,9 +33,9 @@ export class ReviewsService {
   }
 
   update(
-    id: number,
+    id: string,
     updateReviewDto: UpdateReviewDto,
-  ): ApiSuccessResponse<{ id: number; review: UpdateReviewDto }> {
+  ): ApiSuccessResponse<{ id: string; review: UpdateReviewDto }> {
     void updateReviewDto;
 
     return CrudResponse(DbModels.COMPANY_REVIEW, CrudEnums.UPDATE, {
@@ -44,7 +44,7 @@ export class ReviewsService {
     });
   }
 
-  remove(id: number): ApiSuccessResponse<string> {
+  remove(id: string): ApiSuccessResponse<string> {
     return CrudResponse(
       DbModels.COMPANY_REVIEW,
       CrudEnums.DELETE,


### PR DESCRIPTION
## Problem

The `reviews` controller and service treat review IDs as numbers, but the Prisma schema defines `company_review.id` as a `cuid` string (e.g. `cmbabcd1234`). The controller's `findOne`, `update`, and `remove` handlers coerce the route param with `+id`, which produces `NaN` for any real cuid. The service signatures (`id: number`) cement the wrong type through the stack.

Separately, `CreateReviewDto` is an empty class — any request body is accepted without validation. While the service is currently stubbed, `POST /reviews` and `PATCH /reviews/:id` shouldn't document or accept arbitrary payloads in Swagger; the DTO is also what a real service implementation will need to consume.

## Approach

Two narrow changes to the `reviews` module, nothing else touched:

1. Change the ID type from `number` to `string` through the controller and service. Specifically:
   - remove `+id` coercion in `reviews.controller.ts` (`findOne`, `update`, `remove`)
   - change `id: number` → `id: string` in `reviews.service.ts` method signatures
   - update the `update` return type annotation accordingly (`id: string`)
2. Flesh out `CreateReviewDto` with `class-validator` decorators and Swagger metadata, matching the style already used in `CreateUserReviewDto` (field shape mirrors the `company_review` Prisma model: `company_id`, `body`, `overall_rating`, `employment_context?`, `would_recommend?`). `UpdateReviewDto` is unchanged — it already extends `PartialType(CreateReviewDto)`.

This PR does not implement the service — the methods still return stubbed `CrudResponse` values. Wiring Prisma, authentication, and status filtering through the reviews module is a larger piece of work that should come with its own issue.

## Testing

- `npm run lint:check` — clean
- `npm run typecheck` — clean
- `npm test` — 76 passed / 12 suites

## Scope

3 files changed, all inside `src/modules/reviews/`. No schema changes, no new dependencies, no changes outside the reviews module.