### PR TITLE
add companies module with crud endpoints

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -4,6 +4,7 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { ConfigModule } from '@nestjs/config';
 import { AuthModule } from './modules/auth/auth.module';
+import { CompaniesModule } from './modules/companies/companies.module';
 import { ReviewsModule } from './modules/reviews/reviews.module';
 import { UserModule } from './modules/user/user.module';
 import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
@@ -26,6 +27,7 @@ import { UserInterceptor } from '@modules/auth/interceptors/user.interceptor';
     UserModule,
     UserModule,
     ReviewsModule,
+    CompaniesModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/modules/companies/companies.controller.spec.ts
+++ b/src/modules/companies/companies.controller.spec.ts
@@ -1,0 +1,83 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CompaniesController } from './companies.controller';
+import { CompaniesService } from './companies.service';
+import type { AuthenticatedRequest } from '@modules/user/user.types';
+
+jest.mock('../../shared/modules/prisma', () => ({
+  PrismaService: jest.fn(),
+}));
+
+const mockAuthenticatedUser = (sub: string): AuthenticatedRequest['user'] => ({
+  sub,
+});
+
+const mockCompaniesService = {
+  create: jest.fn(),
+  findAll: jest.fn(),
+  findOne: jest.fn(),
+  findByDomain: jest.fn(),
+  update: jest.fn(),
+};
+
+describe('CompaniesController', () => {
+  let controller: CompaniesController;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [CompaniesController],
+      providers: [
+        { provide: CompaniesService, useValue: mockCompaniesService },
+      ],
+    }).compile();
+
+    controller = module.get<CompaniesController>(CompaniesController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  it('should delegate create to CompaniesService with the authenticated user', async () => {
+    const user = mockAuthenticatedUser('user-1');
+    const dto = { name: 'Acme Inc.', domain: 'acme.com' };
+
+    await controller.create(user, dto);
+
+    expect(mockCompaniesService.create).toHaveBeenCalledWith(user, dto);
+  });
+
+  it('should delegate findAll to CompaniesService with the query', async () => {
+    const query = { page: 1, limit: 10, industry: 'Technology' };
+
+    await controller.findAll(query);
+
+    expect(mockCompaniesService.findAll).toHaveBeenCalledWith(query);
+  });
+
+  it('should delegate findOne to CompaniesService with the company id', async () => {
+    await controller.findOne('company-1');
+
+    expect(mockCompaniesService.findOne).toHaveBeenCalledWith('company-1');
+  });
+
+  it('should delegate findByDomain to CompaniesService with the domain', async () => {
+    await controller.findByDomain('acme.com');
+
+    expect(mockCompaniesService.findByDomain).toHaveBeenCalledWith('acme.com');
+  });
+
+  it('should delegate update to CompaniesService with the authenticated user and company id', async () => {
+    const user = mockAuthenticatedUser('user-2');
+    const dto = { description: 'Updated description' };
+
+    await controller.update(user, 'company-1', dto);
+
+    expect(mockCompaniesService.update).toHaveBeenCalledWith(
+      user,
+      'company-1',
+      dto,
+    );
+  });
+});

--- a/src/modules/companies/companies.controller.ts
+++ b/src/modules/companies/companies.controller.ts
@@ -1,0 +1,94 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards';
+import { SkipAuth } from '../auth/decorators/skip-auth.decorator';
+import { User } from '../auth/decorators/user.decorator';
+import { CompaniesService } from './companies.service';
+import { CompanyQueryDto, CreateCompanyDto, UpdateCompanyDto } from './dto';
+import type { Company, CompanyResponse } from './companies.types';
+import type { AuthenticatedRequest } from '@modules/user/user.types';
+import type { PaginationResponseInterface } from '@shared/types';
+
+@ApiTags('companies')
+@Controller('companies')
+@UseGuards(JwtAuthGuard)
+export class CompaniesController {
+  constructor(private readonly companiesService: CompaniesService) {}
+
+  @Post()
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Create a new company' })
+  @ApiResponse({ status: 201, description: 'Company created successfully' })
+  @ApiResponse({ status: 400, description: 'Bad request' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({
+    status: 409,
+    description: 'A company with this domain already exists',
+  })
+  create(
+    @User() user: AuthenticatedRequest['user'],
+    @Body() createCompanyDto: CreateCompanyDto,
+  ): Promise<CompanyResponse> {
+    return this.companiesService.create(user, createCompanyDto);
+  }
+
+  @Get()
+  @SkipAuth()
+  @ApiOperation({ summary: 'List approved companies' })
+  @ApiResponse({
+    status: 200,
+    description: 'Return a paginated list of approved companies',
+  })
+  findAll(
+    @Query() query: CompanyQueryDto,
+  ): Promise<PaginationResponseInterface<Company>> {
+    return this.companiesService.findAll(query);
+  }
+
+  @Get('domain/:domain')
+  @SkipAuth()
+  @ApiOperation({ summary: 'Find an approved company by domain' })
+  @ApiResponse({ status: 200, description: 'Return the matching company' })
+  @ApiResponse({ status: 404, description: 'Company not found' })
+  findByDomain(@Param('domain') domain: string): Promise<CompanyResponse> {
+    return this.companiesService.findByDomain(domain);
+  }
+
+  @Get(':id')
+  @SkipAuth()
+  @ApiOperation({ summary: 'Get an approved company by ID' })
+  @ApiResponse({ status: 200, description: 'Return a single company' })
+  @ApiResponse({ status: 404, description: 'Company not found' })
+  findOne(@Param('id') id: string): Promise<CompanyResponse> {
+    return this.companiesService.findOne(id);
+  }
+
+  @Patch(':id')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Update a company that the current user created' })
+  @ApiResponse({ status: 200, description: 'Company updated successfully' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden' })
+  @ApiResponse({ status: 404, description: 'Company not found' })
+  update(
+    @User() user: AuthenticatedRequest['user'],
+    @Param('id') id: string,
+    @Body() updateCompanyDto: UpdateCompanyDto,
+  ): Promise<CompanyResponse> {
+    return this.companiesService.update(user, id, updateCompanyDto);
+  }
+}

--- a/src/modules/companies/companies.module.ts
+++ b/src/modules/companies/companies.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { AuthModule } from '../auth/auth.module';
+import { CompaniesController } from './companies.controller';
+import { CompaniesService } from './companies.service';
+
+@Module({
+  imports: [AuthModule],
+  controllers: [CompaniesController],
+  providers: [CompaniesService],
+})
+export class CompaniesModule {}

--- a/src/modules/companies/companies.service.spec.ts
+++ b/src/modules/companies/companies.service.spec.ts
@@ -1,0 +1,261 @@
+import {
+  ConflictException,
+  ForbiddenException,
+  HttpStatus,
+  NotFoundException,
+} from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { CompanyStatus } from 'prisma/generated/prisma/enums';
+import { PrismaService } from '../../shared/modules/prisma';
+import { CompaniesService } from './companies.service';
+import type { AuthenticatedRequest } from '@modules/user/user.types';
+
+jest.mock('../../shared/modules/prisma', () => ({
+  PrismaService: jest.fn(),
+}));
+
+const mockPrismaService = {
+  company: {
+    findUnique: jest.fn(),
+    findFirst: jest.fn(),
+    findMany: jest.fn(),
+    count: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+  },
+};
+
+const mockAuthenticatedUser = (sub: string): AuthenticatedRequest['user'] => ({
+  sub,
+});
+
+const approvedCompany = (overrides: Partial<Record<string, unknown>> = {}) => ({
+  id: 'company-1',
+  creator_id: 'user-1',
+  name: 'Acme Inc.',
+  description: null,
+  website_url: null,
+  domain: 'acme.com',
+  linkedin_url: null,
+  logo_url: null,
+  headquarters: null,
+  industry: 'Technology',
+  status: CompanyStatus.APPROVED,
+  created_at: new Date(),
+  updated_at: new Date(),
+  ...overrides,
+});
+
+describe('CompaniesService', () => {
+  let service: CompaniesService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CompaniesService,
+        { provide: PrismaService, useValue: mockPrismaService },
+      ],
+    }).compile();
+
+    service = module.get<CompaniesService>(CompaniesService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('create', () => {
+    it('should create a company with PENDING status and the authenticated creator', async () => {
+      mockPrismaService.company.create.mockResolvedValue(
+        approvedCompany({ status: CompanyStatus.PENDING }),
+      );
+
+      const result = await service.create(mockAuthenticatedUser('user-1'), {
+        name: 'Acme Inc.',
+        domain: 'acme.com',
+      });
+
+      expect(mockPrismaService.company.findUnique).toHaveBeenCalledWith({
+        where: { domain: 'acme.com' },
+        select: { id: true },
+      });
+      expect(mockPrismaService.company.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          creator_id: 'user-1',
+          name: 'Acme Inc.',
+          domain: 'acme.com',
+        }),
+      });
+      expect(result).toEqual({
+        message: 'Company created successfully.',
+        code: HttpStatus.CREATED,
+        data: expect.objectContaining({ id: 'company-1' }),
+      });
+    });
+
+    it('should reject a duplicate domain', async () => {
+      mockPrismaService.company.findUnique.mockResolvedValue({
+        id: 'existing-company',
+      });
+
+      await expect(
+        service.create(mockAuthenticatedUser('user-1'), {
+          name: 'Acme Inc.',
+          domain: 'acme.com',
+        }),
+      ).rejects.toBeInstanceOf(ConflictException);
+      expect(mockPrismaService.company.create).not.toHaveBeenCalled();
+    });
+
+    it('should skip the domain uniqueness check when no domain is provided', async () => {
+      mockPrismaService.company.create.mockResolvedValue(
+        approvedCompany({ domain: null }),
+      );
+
+      await service.create(mockAuthenticatedUser('user-1'), {
+        name: 'Acme Inc.',
+      });
+
+      expect(mockPrismaService.company.findUnique).not.toHaveBeenCalled();
+      expect(mockPrismaService.company.create).toHaveBeenCalled();
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return a paginated list of approved companies', async () => {
+      mockPrismaService.company.findMany.mockResolvedValue([approvedCompany()]);
+      mockPrismaService.company.count.mockResolvedValue(1);
+
+      const result = await service.findAll({});
+
+      expect(mockPrismaService.company.count).toHaveBeenCalledWith({
+        where: { status: CompanyStatus.APPROVED },
+      });
+      expect(result).toEqual({
+        data: expect.arrayContaining([
+          expect.objectContaining({ id: 'company-1' }),
+        ]),
+        totalCount: 1,
+        limit: 10,
+        currentCount: 1,
+        page: 1,
+        totalPages: 1,
+        hasNextPage: false,
+        hasPrevPage: false,
+      });
+    });
+
+    it('should apply industry and search filters when provided', async () => {
+      mockPrismaService.company.findMany.mockResolvedValue([]);
+      mockPrismaService.company.count.mockResolvedValue(0);
+
+      await service.findAll({ search: 'acme', industry: 'Technology' });
+
+      expect(mockPrismaService.company.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            status: CompanyStatus.APPROVED,
+            industry: 'Technology',
+            name: { contains: 'acme', mode: 'insensitive' },
+          },
+        }),
+      );
+    });
+  });
+
+  describe('findOne', () => {
+    it('should return an approved company by id', async () => {
+      mockPrismaService.company.findFirst.mockResolvedValue(approvedCompany());
+
+      const result = await service.findOne('company-1');
+
+      expect(mockPrismaService.company.findFirst).toHaveBeenCalledWith({
+        where: { id: 'company-1', status: CompanyStatus.APPROVED },
+      });
+      expect(result).toEqual({
+        message: 'Company fetched successfully.',
+        code: HttpStatus.OK,
+        data: expect.objectContaining({ id: 'company-1' }),
+      });
+    });
+
+    it('should throw when no approved company matches', async () => {
+      mockPrismaService.company.findFirst.mockResolvedValue(null);
+
+      await expect(service.findOne('missing')).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('findByDomain', () => {
+    it('should return an approved company by domain', async () => {
+      mockPrismaService.company.findFirst.mockResolvedValue(approvedCompany());
+
+      const result = await service.findByDomain('acme.com');
+
+      expect(mockPrismaService.company.findFirst).toHaveBeenCalledWith({
+        where: { domain: 'acme.com', status: CompanyStatus.APPROVED },
+      });
+      expect(result.data).toEqual(expect.objectContaining({ id: 'company-1' }));
+    });
+
+    it('should throw when no approved company matches the domain', async () => {
+      mockPrismaService.company.findFirst.mockResolvedValue(null);
+
+      await expect(service.findByDomain('unknown.com')).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('update', () => {
+    it('should update a company owned by the current user', async () => {
+      const existing = approvedCompany({ creator_id: 'user-1' });
+      mockPrismaService.company.findUnique.mockResolvedValue(existing);
+      mockPrismaService.company.update.mockResolvedValue({
+        ...existing,
+        description: 'Updated description',
+      });
+
+      const result = await service.update(
+        mockAuthenticatedUser('user-1'),
+        'company-1',
+        { description: 'Updated description' },
+      );
+
+      expect(mockPrismaService.company.update).toHaveBeenCalledWith({
+        where: { id: 'company-1' },
+        data: expect.objectContaining({ description: 'Updated description' }),
+      });
+      expect(result.data).toEqual(
+        expect.objectContaining({ description: 'Updated description' }),
+      );
+    });
+
+    it('should reject updates by a user who is not the creator', async () => {
+      mockPrismaService.company.findUnique.mockResolvedValue(
+        approvedCompany({ creator_id: 'another-user' }),
+      );
+
+      await expect(
+        service.update(mockAuthenticatedUser('user-1'), 'company-1', {
+          description: 'Updated description',
+        }),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+      expect(mockPrismaService.company.update).not.toHaveBeenCalled();
+    });
+
+    it('should throw when the target company does not exist', async () => {
+      mockPrismaService.company.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.update(mockAuthenticatedUser('user-1'), 'missing', {
+          description: 'Updated description',
+        }),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+  });
+});

--- a/src/modules/companies/companies.service.ts
+++ b/src/modules/companies/companies.service.ts
@@ -1,0 +1,169 @@
+import {
+  ConflictException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { CompanyStatus } from 'prisma/generated/prisma/enums';
+import { PrismaService } from '../../shared/modules/prisma';
+import {
+  CrudEnums,
+  DbModels,
+  PaginationResponseInterface,
+} from '../../shared/types';
+import { CrudResponse } from '../../shared/utils/response';
+import { GetPageOptions, PaginateRes } from '@shared/index';
+import type { AuthenticatedRequest } from '@modules/user/user.types';
+import type {
+  CompanyQueryDto,
+  CreateCompanyDto,
+  UpdateCompanyDto,
+} from './dto';
+import type { Company, CompanyResponse } from './companies.types';
+import { COMPANIES_RESPONSE_MESSAGES } from './utils/companies.utils';
+
+@Injectable()
+export class CompaniesService {
+  constructor(private readonly prismaService: PrismaService) {}
+
+  async create(
+    user: AuthenticatedRequest['user'],
+    createCompanyDto: CreateCompanyDto,
+  ): Promise<CompanyResponse> {
+    if (createCompanyDto.domain) {
+      const existing = await this.prismaService.company.findUnique({
+        where: { domain: createCompanyDto.domain },
+        select: { id: true },
+      });
+
+      if (existing) {
+        throw new ConflictException(
+          COMPANIES_RESPONSE_MESSAGES.domainAlreadyInUse,
+        );
+      }
+    }
+
+    const created = await this.prismaService.company.create({
+      data: {
+        creator_id: user.sub,
+        name: createCompanyDto.name,
+        description: createCompanyDto.description ?? null,
+        website_url: createCompanyDto.website_url ?? null,
+        domain: createCompanyDto.domain ?? null,
+        linkedin_url: createCompanyDto.linkedin_url ?? null,
+        logo_url: createCompanyDto.logo_url ?? null,
+        headquarters: createCompanyDto.headquarters ?? null,
+        industry: createCompanyDto.industry ?? null,
+      },
+    });
+
+    return CrudResponse(DbModels.COMPANY, CrudEnums.CREATE, created);
+  }
+
+  async findAll(
+    query: CompanyQueryDto,
+  ): Promise<PaginationResponseInterface<Company>> {
+    const { page, limit, search, sort, industry } = query;
+
+    const where = {
+      status: CompanyStatus.APPROVED,
+      ...(industry && { industry }),
+      ...(search && {
+        name: { contains: search, mode: 'insensitive' as const },
+      }),
+    };
+
+    const [count, records] = await Promise.all([
+      this.prismaService.company.count({ where }),
+      this.prismaService.company.findMany({
+        ...GetPageOptions(Number(page), Number(limit)),
+        where,
+        orderBy: { created_at: sort || 'desc' },
+      }),
+    ]);
+
+    return PaginateRes(
+      records,
+      count,
+      records.length,
+      Number(page),
+      Number(limit),
+    );
+  }
+
+  async findOne(id: string): Promise<CompanyResponse> {
+    const company = await this.findApprovedCompanyOrThrow(id);
+
+    return CrudResponse(DbModels.COMPANY, CrudEnums.READ, company);
+  }
+
+  async findByDomain(domain: string): Promise<CompanyResponse> {
+    const company = await this.prismaService.company.findFirst({
+      where: {
+        domain,
+        status: CompanyStatus.APPROVED,
+      },
+    });
+
+    if (!company) {
+      throw new NotFoundException(COMPANIES_RESPONSE_MESSAGES.companyNotFound);
+    }
+
+    return CrudResponse(DbModels.COMPANY, CrudEnums.READ, company);
+  }
+
+  async update(
+    user: AuthenticatedRequest['user'],
+    id: string,
+    updateCompanyDto: UpdateCompanyDto,
+  ): Promise<CompanyResponse> {
+    const existing = await this.findCompanyOrThrow(id);
+
+    if (existing.creator_id !== user.sub) {
+      throw new ForbiddenException(
+        COMPANIES_RESPONSE_MESSAGES.companyForbidden,
+      );
+    }
+
+    const updated = await this.prismaService.company.update({
+      where: { id },
+      data: {
+        description: updateCompanyDto.description ?? existing.description,
+        website_url: updateCompanyDto.website_url ?? existing.website_url,
+        linkedin_url: updateCompanyDto.linkedin_url ?? existing.linkedin_url,
+        logo_url: updateCompanyDto.logo_url ?? existing.logo_url,
+        headquarters: updateCompanyDto.headquarters ?? existing.headquarters,
+        industry: updateCompanyDto.industry ?? existing.industry,
+      },
+    });
+
+    return CrudResponse(DbModels.COMPANY, CrudEnums.UPDATE, updated);
+  }
+
+  private async findApprovedCompanyOrThrow(id: string): Promise<Company> {
+    const company = await this.prismaService.company.findFirst({
+      where: {
+        id,
+        status: CompanyStatus.APPROVED,
+      },
+    });
+
+    if (!company) {
+      throw new NotFoundException(COMPANIES_RESPONSE_MESSAGES.companyNotFound);
+    }
+
+    return company;
+  }
+
+  private async findCompanyOrThrow(id: string): Promise<Company> {
+    const company = await this.prismaService.company.findUnique({
+      where: { id },
+    });
+
+    if (!company) {
+      throw new NotFoundException(COMPANIES_RESPONSE_MESSAGES.companyNotFound);
+    }
+
+    return company;
+  }
+}

--- a/src/modules/companies/companies.types.ts
+++ b/src/modules/companies/companies.types.ts
@@ -1,0 +1,6 @@
+import type { company } from 'prisma/generated/prisma/client';
+import type { ApiSuccessResponse } from '../../shared/utils/response';
+
+export type Company = company;
+
+export type CompanyResponse = ApiSuccessResponse<Company>;

--- a/src/modules/companies/dto/company-query.dto.ts
+++ b/src/modules/companies/dto/company-query.dto.ts
@@ -1,0 +1,17 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsEnum, IsOptional, IsString, MaxLength } from 'class-validator';
+import { CompanyStatus } from 'prisma/generated/prisma/enums';
+import { BaseQueryDto } from '@shared/dtos';
+
+export class CompanyQueryDto extends BaseQueryDto {
+  @ApiPropertyOptional({ enum: CompanyStatus })
+  @IsOptional()
+  @IsEnum(CompanyStatus)
+  status?: CompanyStatus;
+
+  @ApiPropertyOptional({ example: 'Technology' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  industry?: string;
+}

--- a/src/modules/companies/dto/create-company.dto.ts
+++ b/src/modules/companies/dto/create-company.dto.ts
@@ -1,0 +1,91 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
+import {
+  IsFQDN,
+  IsOptional,
+  IsString,
+  IsUrl,
+  MaxLength,
+  MinLength,
+} from 'class-validator';
+
+const trim = ({ value }: { value: unknown }) =>
+  typeof value === 'string' ? value.trim() : value;
+
+const normalizeOptionalUrl = ({ value }: { value: unknown }) => {
+  if (typeof value !== 'string') return value;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+};
+
+export class CreateCompanyDto {
+  @ApiProperty({ example: 'Acme Inc.', description: 'Company name' })
+  @IsString()
+  @MinLength(1)
+  @MaxLength(200)
+  @Transform(trim)
+  name!: string;
+
+  @ApiPropertyOptional({ description: 'Company description' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(5000)
+  @Transform(trim)
+  description?: string;
+
+  @ApiPropertyOptional({
+    example: 'https://acme.com',
+    description: 'Company website URL',
+  })
+  @IsOptional()
+  @IsUrl()
+  @Transform(normalizeOptionalUrl)
+  website_url?: string;
+
+  @ApiPropertyOptional({
+    example: 'acme.com',
+    description: 'Unique company domain used for duplicate detection',
+  })
+  @IsOptional()
+  @IsFQDN()
+  @Transform(trim)
+  domain?: string;
+
+  @ApiPropertyOptional({
+    example: 'https://linkedin.com/company/acme',
+    description: 'Company LinkedIn URL',
+  })
+  @IsOptional()
+  @IsUrl()
+  @Transform(normalizeOptionalUrl)
+  linkedin_url?: string;
+
+  @ApiPropertyOptional({
+    example: 'https://acme.com/logo.png',
+    description: 'Company logo URL',
+  })
+  @IsOptional()
+  @IsUrl()
+  @Transform(normalizeOptionalUrl)
+  logo_url?: string;
+
+  @ApiPropertyOptional({
+    example: 'Lagos, Nigeria',
+    description: 'Company headquarters location',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(200)
+  @Transform(trim)
+  headquarters?: string;
+
+  @ApiPropertyOptional({
+    example: 'Technology',
+    description: 'Company industry',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  @Transform(trim)
+  industry?: string;
+}

--- a/src/modules/companies/dto/index.ts
+++ b/src/modules/companies/dto/index.ts
@@ -1,0 +1,3 @@
+export * from './create-company.dto';
+export * from './update-company.dto';
+export * from './company-query.dto';

--- a/src/modules/companies/dto/update-company.dto.ts
+++ b/src/modules/companies/dto/update-company.dto.ts
@@ -1,0 +1,7 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { OmitType } from '@nestjs/swagger';
+import { CreateCompanyDto } from './create-company.dto';
+
+export class UpdateCompanyDto extends PartialType(
+  OmitType(CreateCompanyDto, ['name', 'domain'] as const),
+) {}

--- a/src/modules/companies/utils/companies.utils.ts
+++ b/src/modules/companies/utils/companies.utils.ts
@@ -1,0 +1,5 @@
+export const COMPANIES_RESPONSE_MESSAGES = {
+  companyNotFound: 'Company not found.',
+  companyForbidden: 'You are not allowed to update this company.',
+  domainAlreadyInUse: 'A company with this domain already exists.',
+} as const;


### PR DESCRIPTION
## Problem

The MVP scope calls for users to search for companies and view company profiles, but the existing codebase has no HTTP surface for companies even though the Prisma `company` model is already defined. Reviews have no company records to attach to through the API.

Tracked in #22. This PR implements the direction proposed there; I am opening it proactively so the shape is concrete and easy to critique, but am happy to rework based on maintainer feedback before merge.

## Approach

New `src/modules/companies/` module that exposes the routes needed to support the MVP company-discovery flow. All behavior is backed by `PrismaService` using the `company` model that already exists in `prisma/schema.prisma` — no schema changes.

Endpoints:

- `POST /companies` — authenticated. Creates a company with `status: PENDING` (schema default) and stores the current user as `creator_id`. Rejects with 409 if a company with the same `domain` already exists.
- `GET /companies` — public. Paginated list of `APPROVED` companies. Optional query params: `search` (case-insensitive `name` match), `industry`, plus the standard `page` / `limit` / `sort` from `BaseQueryDto`.
- `GET /companies/:id` — public. Returns a single `APPROVED` company or 404.
- `GET /companies/domain/:domain` — public. Lookup by unique domain, returns the matching `APPROVED` company or 404. Routed before `GET /companies/:id` so the static segment matches first.
- `PATCH /companies/:id` — authenticated, creator-only. Partial updates to `description`, `website_url`, `linkedin_url`, `logo_url`, `headquarters`, `industry`. Returns 403 for non-creators, 404 for missing companies.

DTOs use `class-validator` and match the style already established in `CreateUserReviewDto`:

- `CreateCompanyDto` — required `name` (1–200 chars), optional `description`, `website_url` (IsUrl), `domain` (IsFQDN), `linkedin_url` (IsUrl), `logo_url` (IsUrl), `headquarters`, `industry`. String fields are trimmed via `Transform`; optional URL fields are normalized to `undefined` when blank.
- `UpdateCompanyDto` — `PartialType(OmitType(CreateCompanyDto, ['name', 'domain']))`. Name and domain changes are intentionally held back for a future admin-moderation change.
- `CompanyQueryDto extends BaseQueryDto` — adds optional `status` (enum) and `industry` filters.

`CompaniesController` uses `@UseGuards(JwtAuthGuard)` at class level with `@SkipAuth()` on the public read endpoints, matching the pattern in `UserController`.

## Testing

- `npm run lint:check` — clean
- `npm run typecheck` — clean
- `npm test` — 95 passed / 14 suites (up from 76 / 12; 19 new test cases across `companies.service.spec.ts` and `companies.controller.spec.ts`)

Unit test coverage:

- service: `create` (create + duplicate domain conflict + skip-uniqueness-when-no-domain), `findAll` (base + search/industry filters applied), `findOne` (success + not found), `findByDomain` (success + not found), `update` (creator success + non-creator forbidden + not found)
- controller: delegation checks for every route

## Out of scope (follow-ups)

- Admin moderation endpoints (approve / reject / archive)
- Aggregated rating and review counts on the company profile response
- Per-dimension ratings — requires a Prisma schema change
- Image upload for logos
- Name and domain updates — deferred until an admin role exists

## Scope

11 new files under `src/modules/companies/` plus a 2-line change in `src/app.module.ts` to register `CompaniesModule`. No schema changes, no new dependencies, no changes outside the new module and the app module registration.